### PR TITLE
fix typo

### DIFF
--- a/src/commands/app/create.ts
+++ b/src/commands/app/create.ts
@@ -4,7 +4,7 @@ import Command from '../../base';
 import { Flags } from '@oclif/core';
 import { AVAILABLE_PLATFORMS } from '../../constants';
 import { createDebugLogger } from '../../utils/output';
-import { Spacing } from '../../utils/spacing';
+import spacing from '../../utils/spacing';
 
 export default class AppCreate extends Command {
   static description = 'create an app';
@@ -123,13 +123,13 @@ export default class AppCreate extends Command {
               const storageClass = availablePlan.storageClass;
               return {
                 value: plan,
-                name: `RAM: ${ram}${Spacing(5, ram)}GB,  CPU: ${cpu}${Spacing(
+                name: `RAM: ${ram}${spacing(5, ram)}GB,  CPU: ${cpu}${spacing(
                   5,
                   cpu
-                )}Core,  Disk: ${disk}${Spacing(3, disk) + 'GB'}${
+                )}Core,  Disk: ${disk}${spacing(3, disk) + 'GB'}${
                   storageClass || 'SSD'
                 },  Price: ${price.toLocaleString()}${
-                  price ? Spacing(7, price) + 'Tomans/Month' : ''
+                  price ? spacing(7, price) + 'Tomans/Month' : ''
                 }`,
               };
             }),

--- a/src/commands/plan/list.ts
+++ b/src/commands/plan/list.ts
@@ -1,6 +1,6 @@
 import { CliUx } from '@oclif/core';
 import Command from '../../base';
-import { Spacing } from '../../utils/spacing';
+import spacing from '../../utils/spacing';
 
 export default class PlanList extends Command {
   static description = 'list available plans';
@@ -28,17 +28,17 @@ export default class PlanList extends Command {
         const Plan = plan;
         const availablePlan = plans.projects[plan];
         const tRAM = availablePlan.RAM.amount;
-        const RAM = tRAM + Spacing(5, tRAM) + 'GB';
+        const RAM = tRAM + spacing(5, tRAM) + 'GB';
         const tCPU = availablePlan.CPU.amount;
-        const CPU = tCPU + Spacing(5, tCPU) + 'Core';
+        const CPU = tCPU + spacing(5, tCPU) + 'Core';
         const StorageClass = availablePlan.storageClass;
         const tDisk = availablePlan.volume;
         const Disk = tDisk
-          ? tDisk + Spacing(3, tDisk) + `GB ${StorageClass}`
+          ? tDisk + spacing(3, tDisk) + `GB ${StorageClass}`
           : 0;
         const tPrice = availablePlan.price * 720;
         const Price = tPrice
-          ? tPrice.toLocaleString() + Spacing(7, tPrice) + 'Tomans/Month'
+          ? tPrice.toLocaleString() + spacing(7, tPrice) + 'Tomans/Month'
           : 0;
         return {
           Plan,

--- a/src/utils/spacing.ts
+++ b/src/utils/spacing.ts
@@ -1,4 +1,4 @@
-export function Spacing(maxLength: number, value: number) {
+export default function spacing(maxLength: number, value: number) {
   const inputLength = value.toString().length;
 
   return inputLength === 1


### PR DESCRIPTION
Native JavaScript functions begin with an uppercase letter to distinguish those functions that are to be used as constructors from functions that are not.