### PR TITLE
fix: detect django and flask platform with weird requirements file

### DIFF
--- a/src/utils/add-null-between-chars.ts
+++ b/src/utils/add-null-between-chars.ts
@@ -1,0 +1,18 @@
+function addNullBetweenChars(input: string): Buffer {
+  const buffer = Buffer.alloc(input.length * 2 - 1);
+  let offset = 0;
+
+  for (let i = 0; i < input.length; i++) {
+    buffer.write(input.charAt(i), offset);
+    // if current character is not the last one, write a null character after it
+    if (i !== input.length - 1) {
+      offset++;
+      buffer.write('\0', offset);
+      offset++;
+    }
+  }
+
+  return buffer;
+}
+
+export default addNullBetweenChars;

--- a/src/utils/detect-platform.ts
+++ b/src/utils/detect-platform.ts
@@ -4,6 +4,8 @@ import fs from 'fs-extra';
 
 const { readJSONSync, existsSync, readFileSync } = fs;
 
+import addNullBetweenChars from './add-null-between-chars.js';
+
 export default function detectPlatform(projectPath: string) {
   const pipfilePath = path.join(projectPath, 'Pipfile');
   const indexPHPFilePath = path.join(projectPath, 'index.php');
@@ -72,14 +74,18 @@ Please specify your platform with --platform=laravel or docker.`);
 
     if (
       requirementsTxt.includes('Django') ||
-      requirementsTxt.includes('django')
+      requirementsTxt.includes('django') ||
+      requirementsTxt.includes(addNullBetweenChars('Django')) ||
+      requirementsTxt.includes(addNullBetweenChars('django'))
     ) {
       return 'django';
     }
 
     if (
       requirementsTxt.includes('Flask') ||
-      requirementsTxt.includes('flask')
+      requirementsTxt.includes('flask') ||
+      requirementsTxt.includes(addNullBetweenChars('Flask')) ||
+      requirementsTxt.includes(addNullBetweenChars('flask'))
     ) {
       return 'flask';
     }


### PR DESCRIPTION
This pull request addresses an issue with the `requirements.txt` files that contain Null characters (\0) between other characters. This issue can prevent `Django` and `Flask` platforms from detecting correctly.
