### PR TITLE
fix: resolve error when archiving file starts with @

### DIFF
--- a/src/utils/create-archive.ts
+++ b/src/utils/create-archive.ts
@@ -150,15 +150,24 @@ export default async function createArchive(
     return false;
   };
 
-  const fileList: string[] = fs.readdirSync(projectPath).filter(ignoreFN);
+  const addPrefix = (input: string): string => {
+    if (input.startsWith('@')) {
+      return `./${input}`;
+    }
+    return input;
+  };
 
-  return await tar.create(
+  const fileList: string[] = fs
+    .readdirSync(projectPath)
+    .filter(ignoreFN)
+    .map(addPrefix);
+
+  return tar.create(
     {
       gzip: {
         level: 9,
       },
       cwd: projectPath,
-      filter: ignoreFN,
       file: archivePath,
     },
     fileList


### PR DESCRIPTION
This pull request includes the following changes:

- Removed redundant "await" keyword.
- Revised the usage of `ignoreFN` for filtering ignore files. Initially, it was being applied twice, once during the creation of the `fileList` and again within the `tar.create` function. This redundancy was identified, along with a bug where the function that `tar.create` accepts two arguments, while `ignoreFN` only takes one. As a result, the filter from the `tar.create` function has been removed.
- according to the tar documentation, if a file name starts with `@`, it needs to be prepended with `./`. This adjustment has been made accordingly.